### PR TITLE
feat: add script to remove untagged images

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ The script allows me to easily see if there are some data volumes on my disk tha
 up a lot of space and are not needed anymore.
 
 You can find more details in my blog post [Listing information for all your named/unnamed data volumes](https://www.guidodiepen.nl/2017/04/listing-information-for-all-your-named-unnamed-data-volumes/)
+
+## docker_remove_untagged_img.sh
+
+The purpose for this script is to remove all untagged images from the docker local registry.
+When building the same docker images multiple times, it is easy to leave a lot of them behind
+without tags, especially when using `<latest>` tags. These eat up precious space in the
+hard drive and have little benefit. The convenience script run the `docker rmi` command for all
+images with no tags assigned.

--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ You can find more details in my blog post [Listing information for all your name
 The purpose for this script is to remove all untagged images from the docker local registry.
 When building the same docker images multiple times, it is easy to leave a lot of them behind
 without tags, especially when using `<latest>` tags. These eat up precious space in the
-hard drive and have little benefit. The convenience script run the `docker rmi` command for all
+hard drive and have little benefit. The convenience script executes the `docker rmi` command for all
 images with no tags assigned.

--- a/docker_remove_untagged_img.sh
+++ b/docker_remove_untagged_img.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ! "$(docker images | grep "^<none>" | awk '{print $3}')" ]; then
+  echo "No untagged images to remove. Exiting."
+  exit 0
+fi
+
+echo "Removing all untagged images..."
+docker rmi $(docker images | grep "^<none>" | awk '{print $3}')
+
+echo "Done."


### PR DESCRIPTION
When using docker all the time to develop new images it is common to
leave a lot of untagged images behind. The
`docker_remove_untagged_img.sh` removes all docker images from local
storage that are not currently assigned to any tag